### PR TITLE
#51 fixed time zone

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+#*.c text
+#*.h text
+
+# Declare files that will always have CRLF line endings on checkout.
+#*.sln text eol=crlf
+*.sh text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+#*.png binary
+#*.jpg binary

--- a/libraries/system.sh
+++ b/libraries/system.sh
@@ -391,7 +391,7 @@ function system::generate_hosts()
 function system::set_timezone()
 {
     local root_mount="$1"
-    local timezone="$1"
+    local timezone="$2"
 
     arch-chroot "${root_mount}" "ln" "-s" "/usr/share/zoneinfo/${timezone}" "/etc/localtime"
     arch-chroot "${root_mount}" "hwclock" "--systohc" "--utc"
@@ -864,6 +864,8 @@ function system::install()
     system::generate_fstab "${root_mount}"
 
     system::set_locale "${root_mount}" "${config["locale"]}"
+
+    system::set_timezone "${root_mount}" "${config["timezone"]}"
 
     system::set_key_map "${root_mount}" "${config["key_map"]}"
 


### PR DESCRIPTION
fixed time zone setting function and adding a spot in the setup to call the function. Tested by reinstalling linux on my laptop. Had some issues with github for windows wanting to auto change all 'end of line' characters to CRLF in stead of the LF linux apparently uses. Had to add a .gitattributes file to fix it, couldn't find any options in the app to adjust it >.>